### PR TITLE
Move away from setup.py call on Windows

### DIFF
--- a/.ci_support/win_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpython.yaml
@@ -1,7 +1,5 @@
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.8.____cpython.yaml
@@ -1,7 +1,5 @@
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpython.yaml
@@ -1,7 +1,5 @@
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,5 @@
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpython.yaml
@@ -1,7 +1,5 @@
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,7 @@ set CMAKE_GENERATOR=Ninja
 set UNIX_SP_DIR=%SP_DIR:\=/%
 set CMAKE_ARGS=%CMAKE_ARGS% -DPDAL_DIR=$PREFIX -LAH --debug-find -DPYTHON3_NUMPY_INCLUDE_DIRS=%UNIX_SP_DIR%/numpy/core/include
 
-${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
 
 mkdir plugins
 cd plugins

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,13 @@
 
 set CMAKE_GENERATOR=Ninja
-%PYTHON% setup.py install -vv -- -DPython3_EXECUTABLE="%PYTHON%"
 
 
+:: %PYTHON% setup.py install -vv -- -DPython3_EXECUTABLE="%PYTHON%"
+:: scikit-build only passes PYTHON_EXECUTABLE and doesn't pass Python3_EXECUTABLE
+set UNIX_SP_DIR=%SP_DIR:\=/%
+set CMAKE_ARGS=%CMAKE_ARGS% -DPDAL_DIR=$PREFIX -LAH --debug-find -DPYTHON3_NUMPY_INCLUDE_DIRS=%UNIX_SP_DIR%/numpy/core/include
+
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
 
 mkdir plugins
 cd plugins
@@ -10,7 +15,7 @@ curl -OL https://files.pythonhosted.org/packages/ef/a7/eff3213c29a2c5e2c3de594f2
 tar xvf pdal-plugins-1.3.0.tar.gz
 cd pdal-plugins-1.3.0
 
-%PYTHON% -m pip install . -v
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
 cd ../..
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,7 +21,7 @@ fi
 # scikit-build only passes PYTHON_EXECUTABLE and doesn't pass Python3_EXECUTABLE
 export CMAKE_ARGS="${CMAKE_ARGS} -DPDAL_DIR=$PREFIX -LAH --debug-find -DPython3_NumPy_INCLUDE_DIR=$PREFIX/lib/python${PY_VERSION}/site-packages/numpy/core/include/"
 
-${PYTHON} -m pip install . -v
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
 
 mkdir plugins && cd plugins
 curl -OL https://files.pythonhosted.org/packages/ef/a7/eff3213c29a2c5e2c3de594f2459412e3e11f7dff59ad52a8717810c8821/pdal-plugins-1.3.0.tar.gz
@@ -29,7 +29,7 @@ tar xvf pdal-plugins-1.3.0.tar.gz
 cd pdal-plugins-1.3.0
 
 
-${PYTHON} -m pip install . -vv
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
 cd ../..
 
 ACTIVATE_DIR=$PREFIX/etc/conda/activate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 
 build:
-  number: 8
+  number: 9
   skip: true  # [(win and vc<14) or (py<36) or (py<38 and linux)]
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "python-pdal" %}
 {% set version = "3.3.0" %}
-{% set sha256 = "c6ea0b3a6ffa784db7fc74008ee61215bad46b481cf3a4657541b7c598aae0ba" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/PDAL/python/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c6ea0b3a6ffa784db7fc74008ee61215bad46b481cf3a4657541b7c598aae0ba
 
 
 build:
@@ -32,7 +30,6 @@ requirements:
     - {{ pin_compatible('pdal', max_pin='x.x.x') }}
     - ninja
     - scikit-build
-
   host:
     - python
     - pdal
@@ -46,8 +43,12 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   commands:
-    - python -c "import pdal"
+    - pip check
+  imports:
+    - pdal
 
 about:
   home: https://pdal.io


### PR DESCRIPTION
@hobu the previous builds had this warning: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=912184&view=logs&j=2d03c380-16cc-53df-474d-81b5b5dc65ac&t=df791f6b-c996-56df-84d9-327e79a73f8d&l=1845

That, hopefully, we could eliminate in this PR by avoiding the call to setup.py.

PS: Ideally we should also get the plugins as a conda package to avoid pip installing them at build time here. But that I'll leave to another time.